### PR TITLE
Added .clang-format file

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -6,3 +6,4 @@ AlwaysBreakBeforeMultilineStrings: false
 BreakStringLiterals: false
 ColumnLimit: 100
 AllowShortCaseLabelsOnASingleLine: false
+IncludeBlocks: Preserve


### PR DESCRIPTION
Jeg tænkte er det kunne være en god idé at tilføje noget automatisk rettelse af kode formatering så at alt koden ser ud på samme måde. ".clang-format" filen beskriver bare nogle regler som koden vil ændre sig efter. F.eks betyder "`AllowShortFunctionsOnASingleLine: Empty`" at funktioner normalt ser sådan ud:
```c
void function(){
/*something*/
}
```
i stedet for sådan:
```c
void function(){/*something*/}
```
Jeg har bare taget nogle af de regler jeg bruger til mine IMPR opgaver, men i kan bare ændre i dem, eller tilføje nogle hvis i vil.
I kan se alle reglerne her: https://clang.llvm.org/docs/ClangFormatStyleOptions.html
For at bruge autoformatere koden kan i bruge enten:
**clang-format extension i vscode**
https://marketplace.visualstudio.com/items?itemName=xaver.clang-format
**Clangd extension i vscode**
https://marketplace.visualstudio.com/items?itemName=llvm-vs-code-extensions.vscode-clangd
**eller downloade clang-format fra LLVM.org, som er dem der laver clang-format:**
https://llvm.org/builds/